### PR TITLE
Fix code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/app/create/tournament/page.js
+++ b/app/create/tournament/page.js
@@ -108,21 +108,25 @@ export default function Page() {
     setErrorMessage("");
   };
 
+  const validateImageFile = (file) => {
+    return file && file.type.startsWith("image/") && file.size > 0;
+  };
+
   const handleIconUpload = (event) => {
     const file = event.target.files[0];
-    if (file && file.type.substr(0, 5) === "image") {
+    if (validateImageFile(file)) {
       setTournamentIcon(URL.createObjectURL(file));
     } else {
-      alert("Please select an image file");
+      alert("Please select a valid image file");
     }
   };
 
   const handleBannerUpload = (event) => {
     const file = event.target.files[0];
-    if (file && file.type.substr(0, 5) === "image") {
+    if (validateImageFile(file)) {
       setTournamentBanner(URL.createObjectURL(file));
     } else {
-      alert("Please select an image file");
+      alert("Please select a valid image file");
     }
   };
 


### PR DESCRIPTION
Fixes [https://github.com/dinxsh/sanity/security/code-scanning/8](https://github.com/dinxsh/sanity/security/code-scanning/8)

To fix the problem, we should ensure that the URL created from the file object is safe and cannot be exploited for XSS attacks. One way to do this is to use a safer method to handle the file upload and ensure that the URL is only used for image files. We can also add additional validation to ensure the file is indeed an image.

- We will add a function to validate the image file more thoroughly.
- We will update the `handleBannerUpload` function to use this validation function before setting the `tournamentBanner` state.
- We will ensure that the `tournamentBanner` URL is only used if it passes the validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
