### PR TITLE
fix bug

### DIFF
--- a/components/SkeletonTwo.tsx
+++ b/components/SkeletonTwo.tsx
@@ -17,7 +17,7 @@ export const SkeletonTwo = () => {
     // other images...
   ];
 
-  const [rotationValues, setRotationValues] = useState([]);
+  const [rotationValues, setRotationValues] = useState<number[]>([]);
 
   useEffect(() => {
     // Generate random rotation values on the client


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced type safety for `rotationValues` state in `SkeletonTwo` component by explicitly defining it as an array of numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->