### PR TITLE
SAN-74 - added bracket single elimination api

### DIFF
--- a/app/api/brackets/route.js
+++ b/app/api/brackets/route.js
@@ -26,7 +26,7 @@ export async function GET() {
     console.error("Error fetching brackets:", error);
     return new NextResponse(
       JSON.stringify({
-        success: true,
+        success: false,
         data: [],
         message: "Error fetching brackets",
       }),
@@ -168,7 +168,7 @@ function generateSingleElimination(teams, consolationFinal) {
     round++;
   }
   // this is for the consolation final where we decide the 3rd place
-  if (consolationFinal && matches.lenght >= 2) {
+  if (consolationFinal && matches.length >= 2) {
     const semiFinal = [
       matches[matches.length - 2].team1,
       matches[matches.length - 2].team2,

--- a/app/api/brackets/route.js
+++ b/app/api/brackets/route.js
@@ -6,6 +6,35 @@ import Tournament from "../../../model/Tournament";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../../../lib/authOptions";
 
+export async function GET() {
+  try {
+    await dbConnect();
+
+    const session = await getServerSession(authOptions);
+
+    if (!session || !session.user) {
+      return new NextResponse(
+        JSON.stringify({ success: false, message: "Unauthorized" }),
+        { status: 401 },
+      );
+    }
+
+    const brackets = await Bracket.find({ userId: session.user._id });
+
+    return NextResponse.json(brackets, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching brackets:", error);
+    return new NextResponse(
+      JSON.stringify({
+        success: true,
+        data: [],
+        message: "Error fetching brackets",
+      }),
+      { status: 500 },
+    );
+  }
+}
+
 export async function POST(request) {
   try {
     await dbConnect();
@@ -42,6 +71,8 @@ export async function POST(request) {
       );
     }
 
+    let matches = generateMatches(format, teams, consolationFinal);
+
     console.log("UserId", session.user._id);
 
     const newBracket = new Bracket({
@@ -49,6 +80,7 @@ export async function POST(request) {
       format,
       consolationFinal,
       grandFinalType,
+      matches,
       teams,
       userId,
     });
@@ -72,31 +104,85 @@ export async function POST(request) {
   }
 }
 
-export async function GET() {
-  try {
-    await dbConnect();
+function generateMatches(format, teams, consolationFinal) {
+  let matches = [];
 
-    const session = await getServerSession(authOptions);
+  if (format === "single_elimination") {
+    matches = generateSingleElimination(teams, consolationFinal);
+  } else if (format === "double_elimination") {
+    matches = generateDoubleElimination(teams, consolationFinal);
+  } else if (format === "round_robin") {
+    matches = generateRoundRobin(teams);
+  }
 
-    if (!session || !session.user) {
-      return new NextResponse(
-        JSON.stringify({ success: false, message: "Unauthorized" }),
-        { status: 401 },
-      );
+  return matches;
+}
+
+function generateSingleElimination(teams, consolationFinal) {
+  let round = 1;
+  let matches = [];
+  let currentTeams = [...teams];
+
+  // If the number of teams is odd, add a "BYE" team for the perfect match-up
+  if (currentTeams.length % 2 !== 0) {
+    currentTeams.push("BYE");
+  }
+
+  // Generate rounds until we have 1 winner
+  while (currentTeams.length > 1) {
+    let numMatches = currentTeams.length / 2;
+    let roundMatches = [];
+
+    for (let i = 0; i < numMatches; i++) {
+      const team1 = currentTeams[i * 2];
+      const team2 = currentTeams[i * 2 + 1];
+
+      if (team1 !== "BYE" && team2 !== "BYE") {
+        roundMatches.push({
+          round: round,
+          team1: team1,
+          team2: team2,
+          winner: null, // Winner will be determined later
+        });
+      } else if (team1 === "BYE") {
+        roundMatches.push({
+          round: round,
+          team1: team2,
+          team2: null,
+          winner: team2, // Team 2 wins by default
+        });
+      } else if (team2 === "BYE") {
+        roundMatches.push({
+          round: round,
+          team1: team1,
+          team2: null,
+          winner: team1, // Team 1 wins by default
+        });
+      }
     }
 
-    const brackets = await Bracket.find({ userId: session.user._id });
+    matches.push(...roundMatches);
+    // Update the currentTeams array with the winners of the current round
+    currentTeams = roundMatches.map((match) => match.winner);
 
-    return NextResponse.json(brackets, { status: 200 });
-  } catch (error) {
-    console.error("Error fetching brackets:", error);
-    return new NextResponse(
-      JSON.stringify({
-        success: true,
-        data: [],
-        message: "Error fetching brackets",
-      }),
-      { status: 500 },
-    );
+    round++;
   }
+  // this is for the consolation final where we decide the 3rd place
+  if (consolationFinal && matches.lenght >= 2) {
+    const semiFinal = [
+      matches[matches.length - 2].team1,
+      matches[matches.length - 2].team2,
+    ];
+
+    matches.push({
+      round: round,
+      team1: semiFinal[0],
+      team2: semiFinal[1],
+    });
+  }
+  return matches;
 }
+
+function generateDoubleElimination(teams, consolationFinal) {}
+
+function generateRoundRobin(teams) {}

--- a/app/bracket/create/page.js
+++ b/app/bracket/create/page.js
@@ -191,6 +191,7 @@ export default function Page() {
                         <SelectItem value="double_elimination">
                           Double Elimination
                         </SelectItem>
+                        <SelectItem value="round_robin">Round Robin</SelectItem>
                       </SelectContent>
                     </Select>
                   </FormItem>

--- a/model/Bracket.js
+++ b/model/Bracket.js
@@ -15,7 +15,7 @@ const matchSchema = new mongoose.Schema({
   },
   winner: {
     type: String,
-    default: true,
+    default: "",
   },
 });
 

--- a/model/Bracket.js
+++ b/model/Bracket.js
@@ -1,5 +1,24 @@
 import mongoose from "mongoose";
 
+const matchSchema = new mongoose.Schema({
+  round: {
+    type: Number,
+    required: true,
+  },
+  team1: {
+    type: String,
+    required: false,
+  },
+  team2: {
+    type: String,
+    required: false,
+  },
+  winner: {
+    type: String,
+    default: true,
+  },
+});
+
 const bracketSchema = new mongoose.Schema({
   tournament_name: {
     type: String,
@@ -29,6 +48,10 @@ const bracketSchema = new mongoose.Schema({
       },
       message: "Number of teams must be at least 4.",
     },
+  },
+  matches: {
+    type: [matchSchema],
+    required: true,
   },
   userId: {
     type: mongoose.Schema.Types.ObjectId,


### PR DESCRIPTION
In this pr i have added the api logic for the single elimination bracket it contains
- In this it contains logic for single elimination bracket logic.
- Based on no of teams rounds will be decided.
- if consolation is enabled then extra round is added for the third position.

the output looks like :-

<img width="895" alt="image" src="https://github.com/user-attachments/assets/39f55fc2-dbb6-4582-9015-bdd7d7b0e400" />

- here in this for the first round logic will decide the matching and from 2nd round based on the winnings matches will be decided to that's why in round2 `team1` and `team2` is null  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added Round Robin tournament format option when creating brackets
  - Implemented match generation for tournament brackets, including single elimination logic

- **Improvements**
  - Added authentication for bracket retrieval
  - Improved error handling for bracket-related operations

- **Backend Changes**
  - New API endpoint for fetching user-specific brackets
  - Expanded tournament format support with new match generation capabilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->