### PR TITLE
SAN-75 - Added bracket api for the double elimination

### DIFF
--- a/app/api/brackets/route.js
+++ b/app/api/brackets/route.js
@@ -224,7 +224,7 @@ function generateDoubleElimination(teams, consolationFinal) {
   // find the winner of the grand final
   matches.push(grandFinal);
 
-  if (consolationFinal && grandFinal.winner) {
+  if (consolationFinal) {
     // selecting the loser from the grand final for the 3rd place match
     let winnersBracketFinalLoser =
       winnersMatches[winnersMatches.length - 2].winner === grandFinal.team1

--- a/app/api/brackets/route.js
+++ b/app/api/brackets/route.js
@@ -227,15 +227,20 @@ function generateDoubleElimination(teams, consolationFinal) {
   if (consolationFinal) {
     // selecting the loser from the grand final for the 3rd place match
     let winnersBracketFinalLoser =
+      + winnersMatches[winnersMatches.length - 2].winner ?
       winnersMatches[winnersMatches.length - 2].winner === grandFinal.team1
         ? winnersMatches[winnersMatches.length - 2].team2
-        : winnersMatches[winnersMatches.length - 2].team1;
+        : winnersMatches[winnersMatches.length - 2].team1 
+      : null;
+    
     // selecting the looser from the loser bracket for the 3rd place match
     let loserBracektFinalLoser =
+      + loserMatches[loserMatches.length - 1].winner ?
       loserMatches[loserMatches.length - 1].winner === grandFinal.team2
         ? loserMatches[loserMatches.length - 1].team1
-        : loserMatches[loserMatches.length - 1].team2;
-
+        : loserMatches[loserMatches.length - 1].team2
+      : null;
+    
     matches.push({
       round: grandFinal.round + 1,
       team1: winnersBracketFinalLoser,

--- a/app/api/brackets/route.js
+++ b/app/api/brackets/route.js
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import Tournament from "../../../model/Tournament";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../../../lib/authOptions";
+import { type } from "os";
 
 export async function GET() {
   try {
@@ -118,6 +119,8 @@ function generateMatches(format, teams, consolationFinal) {
   return matches;
 }
 
+// This function helps to generate the single elimination bracket for first round
+// and for the later rounds we need to generate the matches based on the winner of the previous round
 function generateSingleElimination(teams, consolationFinal) {
   let round = 1;
   let matches = [];
@@ -183,6 +186,66 @@ function generateSingleElimination(teams, consolationFinal) {
   return matches;
 }
 
-function generateDoubleElimination(teams, consolationFinal) {}
+// This function helps for the initail round of the double elimination bracket to generate the matches
+// for later we need to generate the matches based on the winner and loser bracket manually
+function generateDoubleElimination(teams, consolationFinal) {
+  let matches = [];
+  let winnerBracket = [...teams];
+  let loserBracket = [];
+
+  // reusing the single elimination to generating for the winner bracket
+  let winnersMatches = generateSingleElimination(winnerBracket);
+  matches.push(...winnersMatches);
+
+  let losers = {}; // objects which stores the losers data
+
+  winnersMatches.forEach((match) => {
+    if (!losers[match.round]) losers[match.round] = [];
+    if (match.winner)
+      losers[match.round].push(
+        match.team1 === match.winner ? match.team2 : match.team1,
+      );
+  });
+
+  loserBracket = Object.values(losers).flat().filter(Boolean);
+
+  // generate the loser bracket
+  let loserMatches = generateSingleElimination(loserBracket);
+  matches.push(...loserMatches);
+
+  // generate the grand final
+  let grandFinal = {
+    round: Math.max(...matches.map((match) => match.round)) + 1,
+    team1: null, // we need to add the winner of the winner bracket after conducting the winner bracket final
+    team2: null, // we need to add the winner of the loser bracket after conducting the loser bracket final
+    winner: null,
+    type: "grand_final",
+  };
+  // find the winner of the grand final
+  matches.push(grandFinal);
+
+  if (consolationFinal && grandFinal.winner) {
+    // selecting the loser from the grand final for the 3rd place match
+    let winnersBracketFinalLoser =
+      winnersMatches[winnersMatches.length - 2].winner === grandFinal.team1
+        ? winnersMatches[winnersMatches.length - 2].team2
+        : winnersMatches[winnersMatches.length - 2].team1;
+    // selecting the looser from the loser bracket for the 3rd place match
+    let loserBracektFinalLoser =
+      loserMatches[loserMatches.length - 1].winner === grandFinal.team2
+        ? loserMatches[loserMatches.length - 1].team1
+        : loserMatches[loserMatches.length - 1].team2;
+
+    matches.push({
+      round: grandFinal.round + 1,
+      team1: winnersBracketFinalLoser,
+      team2: loserBracektFinalLoser,
+      winner: null,
+      type: "consolation_final",
+    });
+  }
+
+  return matches;
+}
 
 function generateRoundRobin(teams) {}


### PR DESCRIPTION
In this pr i have added an api for the creation of the bracket for the double elimination

the output looks like this for the first round for later rounds we need add winners and loosers manually:- 

<img width="895" alt="image" src="https://github.com/user-attachments/assets/a80a9515-387f-41b0-84fe-27f63c2732ea" />

the structure of this bracket looks like :- 

![image](https://github.com/user-attachments/assets/1d229f91-1036-4b53-b782-2b03bc453dc2)

if there is any doubt or any suggestion to change in this api suggest them


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced tournament bracket generation with improved support for single and double elimination formats.
  - Added comprehensive logic for creating matches in winner and loser brackets.
  - Implemented support for consolation final matches.

- **Documentation**
  - Added detailed comments explaining tournament bracket generation logic and handling of "BYE" scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->