### PR TITLE
SAN-76: Added round-robin logic for bracket api

### DIFF
--- a/app/api/brackets/route.js
+++ b/app/api/brackets/route.js
@@ -255,6 +255,18 @@ function generateRoundRobin(teams, consolationFinal) {
   let matches = [];
   let numTeams = teams.length;
   let rounds = numTeams % 2 === 0 ? numTeams - 1 : numTeams; // total rounds decided based on number of teams
+  let standings = {};
+
+  // Initialize standings
+  teams.forEach((team) => {
+    standings[team] = {
+      played: 0,
+      wins: 0,
+      draws: 0,
+      losses: 0,
+      points: 0,
+    };
+  });
 
   let schedule = [...teams]; // to track teams for each round
 
@@ -276,6 +288,7 @@ function generateRoundRobin(teams, consolationFinal) {
           team1: team1,
           team2: team2,
           winner: null,
+          standings: standings,
         });
       }
     }

--- a/app/api/brackets/route.js
+++ b/app/api/brackets/route.js
@@ -226,21 +226,20 @@ function generateDoubleElimination(teams, consolationFinal) {
 
   if (consolationFinal) {
     // selecting the loser from the grand final for the 3rd place match
-    let winnersBracketFinalLoser =
-      + winnersMatches[winnersMatches.length - 2].winner ?
-      winnersMatches[winnersMatches.length - 2].winner === grandFinal.team1
+    let winnersBracketFinalLoser = +winnersMatches[winnersMatches.length - 2]
+      .winner
+      ? winnersMatches[winnersMatches.length - 2].winner === grandFinal.team1
         ? winnersMatches[winnersMatches.length - 2].team2
-        : winnersMatches[winnersMatches.length - 2].team1 
+        : winnersMatches[winnersMatches.length - 2].team1
       : null;
-    
+
     // selecting the looser from the loser bracket for the 3rd place match
-    let loserBracektFinalLoser =
-      + loserMatches[loserMatches.length - 1].winner ?
-      loserMatches[loserMatches.length - 1].winner === grandFinal.team2
+    let loserBracektFinalLoser = +loserMatches[loserMatches.length - 1].winner
+      ? loserMatches[loserMatches.length - 1].winner === grandFinal.team2
         ? loserMatches[loserMatches.length - 1].team1
         : loserMatches[loserMatches.length - 1].team2
       : null;
-    
+
     matches.push({
       round: grandFinal.round + 1,
       team1: winnersBracketFinalLoser,
@@ -252,5 +251,49 @@ function generateDoubleElimination(teams, consolationFinal) {
 
   return matches;
 }
+function generateRoundRobin(teams, consolationFinal) {
+  let matches = [];
+  let numTeams = teams.length;
+  let rounds = numTeams % 2 === 0 ? numTeams - 1 : numTeams; // total rounds decided based on number of teams
 
-function generateRoundRobin(teams) {}
+  let schedule = [...teams]; // to track teams for each round
+
+  if (numTeams % 2 !== 0) {
+    schedule.push(null); // a placeholder to keep a team aside when we have odd teams
+    numTeams++;
+  }
+
+  for (let round = 1; round <= rounds; round++) {
+    let roundMatches = [];
+    for (let i = 0; i < numTeams / 2; i++) {
+      let team1 = schedule[i];
+      let team2 = schedule[numTeams - 1 - i];
+
+      if (team1 !== null && team2 !== null) {
+        // to ignore matches with "BYE" which means null team when we have odd teams
+        roundMatches.push({
+          round: round,
+          team1: team1,
+          team2: team2,
+          winner: null,
+        });
+      }
+    }
+    matches.push(...roundMatches);
+    // remove the last team from the array
+    let lastTeam = schedule.pop();
+    schedule.splice(1, 0, lastTeam); // adding the removed team in the index position 1
+  }
+  // adding the consolation final logic for the 3rd place match
+  if (consolationFinal) {
+    let consolationMatch = {
+      round: rounds + 1,
+      team1: null, // these teams can be added based on the final winners
+      team2: null,
+      type: "consolation_final",
+    };
+    matches.push(consolationMatch);
+  }
+
+  return matches;
+}

--- a/app/bracket/create/page.js
+++ b/app/bracket/create/page.js
@@ -30,7 +30,7 @@ const Bracket = dynamic(() => import("../bracket"), { ssr: false }); // to avoid
 
 const bracketSchema = z.object({
   tournament_name: z.string().min(1),
-  format: z.enum(["single_elimination", "double_elimination"]),
+  format: z.enum(["single_elimination", "double_elimination", "round_robin"]),
   consolationFinal: z.boolean().default(false),
   grandFinalType: z.enum(["simple", "double"]),
 });
@@ -64,9 +64,9 @@ export default function Page() {
     resolver: zodResolver(bracketSchema),
     defaultValues: {
       tournament_name: "",
-      format: "single_elimination",
+      format: "",
       consolationFinal: false,
-      grandFinalType: "simple",
+      grandFinalType: "",
     },
   });
 

--- a/model/Bracket.js
+++ b/model/Bracket.js
@@ -27,7 +27,7 @@ const bracketSchema = new mongoose.Schema({
   },
   format: {
     type: String,
-    enum: ["single_elimination", "double_elimination"],
+    enum: ["single_elimination", "double_elimination", "round_robin"],
     required: true,
   },
   consolationFinal: {


### PR DESCRIPTION
In this pr i have added the logic which can create the bracket matches between the teams based on round-robin method(which means each teams will play aganist each other and team with more wins will be the champion)

This is the basic explanation for the logic (ignore the handwriting😅)  :-
![image](https://github.com/user-attachments/assets/7ac7219a-7e4f-47d5-a07b-c9bdb7b8897b)

the output for the logic will looks like :-
![image](https://github.com/user-attachments/assets/d4266181-1a6a-4226-bd1f-035e54aed399)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added round-robin tournament format, giving users an additional option for creating tournaments.

- **Improvements**
  - Enhanced bracket scheduling for more reliable tournament match generation.
  - Updated tournament setup to allow flexible default selections for tournament format and grand final type options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->